### PR TITLE
Make popup filter show matching fields always

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -76,22 +76,25 @@ function formatRecord(object) {
 
 function filterRecord(object, searchTerm) {
   searchTerm = searchTerm.toUpperCase();
+  const objectWithOnlyMatchingKeysOrValues = _.transform(object,
+    function deepFilter(memo, value, key) {
 
-  return _.transform(object, function deepFilter(memo, value, key) {
+    const keyMatches = key.toString().toUpperCase().includes(searchTerm);
+    const valueMatches = value &&
+      value.toString().toUpperCase().includes(searchTerm);
     if (typeof value !== 'object') {
-      if (
-        key.toString().toUpperCase().includes(searchTerm) ||
-        (value && value.toString().toUpperCase().includes(searchTerm))
-      ) {
+      if (keyMatches || valueMatches) {
         memo[key] = value;
       }
     } else {
       let filtered = _.transform(value, deepFilter);
-      if (_.keys(filtered).length) {
+      if (_.keys(filtered).length || keyMatches) {
         memo[key] = filtered;
       }
     }
   });
+
+  return objectWithOnlyMatchingKeysOrValues;
 }
 
 function escapeRegex(str) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -64,10 +64,20 @@ function formatRecord(object) {
           break;
 
         case '_fields':
+          addFieldsWhichAreEmpty(value);
           break;
 
         default:
           memo.bodyFields[key] = value;
+      }
+
+      function addFieldsWhichAreEmpty(fieldsAttributeValue) {
+        const fields = fieldsAttributeValue.split(',');
+        fields.forEach((f) => {
+          if (!memo.hasOwnProperty(f)) {
+            memo[f] = undefined;
+          }
+        });
       }
     },
     {recordType: null, id: null, bodyFields: {}, lineFields: {}}


### PR DESCRIPTION
Previously, if a field of a NS record happened to be an object (e.g. an
Array) and none of its elements matched the search string (typed by the
user in the popup window), then this field would not appear in the
filtered result, misleading the user to think that the field was not
present.

Now the field will always be added to the filtered popup contents, if
it matches the search string